### PR TITLE
#0712100 Enhance bypass_validation to support listedthe vague param body

### DIFF
--- a/galaxy_template/napi.py
+++ b/galaxy_template/napi.py
@@ -48,10 +48,16 @@ def check_parameter_bypass(schema, module_level2_name):
         for key in schema:
             if key != module_level2_name:
                 top_level_schema[key] = schema[key]
-            else:
+            elif not params[module_level2_name] or type(params[module_level2_name]) is dict:
                 top_level_schema[module_level2_name] = dict()
                 top_level_schema[module_level2_name]['required'] = False
                 top_level_schema[module_level2_name]['type'] = 'dict'
+            elif type(params[module_level2_name]) is list:
+                top_level_schema[module_level2_name] = dict()
+                top_level_schema[module_level2_name]['required'] = False
+                top_level_schema[module_level2_name]['type'] = 'list'
+            else:
+                raise Exception('Value of %s must be a dict or list' % (module_level2_name))
         return top_level_schema
     return schema
 


### PR DESCRIPTION
```
$cat group_objectmember.yml
- hosts: fortimanager01
  connection: httpapi
  collections:
  - fortinet.fortimanager
  vars:
   ansible_httpapi_use_ssl: yes
   ansible_httpapi_validate_certs: no
   ansible_httpapi_port: 443
  tasks:
   - name: Add Device To Group
     fmgr_dvmdb_group_objectmember:
        adom: 'root'
        group: 'foogroup'
        state: 'present'
        bypass_validation: True
        dvmdb_group_objectmember:
          - name: 'FGVM02TM20012347'
            vdom: 'root'
          - name: 'FGVM02TM20012348'
            vdom: 'root'
```

when `bypass_validation` is set to `true`, the vague body of `dvmdb_group_objectmember` can also accept a list. 
