### PR TITLE
fix data list with CRUD semantics

### DIFF
--- a/galaxy_template/napi.py
+++ b/galaxy_template/napi.py
@@ -401,7 +401,7 @@ class NAPIManager(object):
     def process_curd(self):
         if 'state' not in self.module.params:
             raise AssertionError('parameter state is expected')
-        has_mkey = self.module_primary_key is not None
+        has_mkey = self.module_primary_key is not None and type(self.module.params[self.module_level2_name]) is dict
         if has_mkey:
             mvalue = ''
             if self.module_primary_key.startswith('complex:'):


### PR DESCRIPTION
```
- hosts: fortimanager01
  connection: httpapi
  collections:
  - fortinet.fortimanager
  vars:
   ansible_httpapi_use_ssl: yes
   ansible_httpapi_validate_certs: no
   ansible_httpapi_port: 443
  tasks:
   - name: Add Device To Group
     fmgr_firewall_address:
        adom: 'root'
        state: 'present'
        bypass_validation: True
        firewall_address:
          - name: demo_1002
            subnet: "10.0.0.2/32"
            comment: This is an ansible test
            color: 11
          - name: demo_1003
            subnet: "10.0.0.3/32"
            comment: This is an ansible test
            color: 11
          - name: demo_1004
            subnet: "10.0.0.4/32"
            comment: This is an ansible test
            color: 11
```