### PR TITLE
Support multi versioning

### DIFF
--- a/galaxy_template/napi.py
+++ b/galaxy_template/napi.py
@@ -85,6 +85,7 @@ class NAPIManager(object):
         self.module_level2_name = self.module_name.split('.')[-1][5:]
         self.top_level_schema_name = top_level_schema_name
         self.system_status = self.get_system_status()
+        self.version_check_warnings = list()
 
     def process_workspace_lock(self):
         self.conn.process_workspace_locking(self.module.params)
@@ -93,6 +94,40 @@ class NAPIManager(object):
         if 'proposed_method' in self.module.params and self.module.params['proposed_method']:
             return self.module.params['proposed_method']
         return default_method
+
+    def _version_matched(self, revisions):
+        assert(revisions)
+        if not self.system_status:
+            # if system version is not determined, give up version checking
+            return True, None
+
+        sys_version_value = int(self.system_status['Major']) * 10000 + int(self.system_status['Minor']) * 100 + int(self.system_status['Patch'])
+        versions = list(revisions.keys())
+        versions.sort(key=lambda x: int(x.split('.')[0]) * 10000 + int(x.split('.')[1]) * 100 + int(x.split('.')[2]))
+        nearest_index = -1
+        for i in range(len(versions)):
+            version_value = int(versions[i].split('.')[0]) * 10000 + int(versions[i].split('.')[1]) * 100 + int(versions[i].split('.')[2])
+            if version_value <= sys_version_value:
+                nearest_index = i
+        if nearest_index == -1:
+            return False, 'not supported until in v%s' % (versions[0])
+        if revisions[versions[nearest_index]] is True:
+            return True, None
+        latest_index = -1
+        for i in range(nearest_index + 1, len(versions)):
+            if revisions[versions[i]] is True:
+                latest_index = i
+                break
+        earliest_index = nearest_index
+        while earliest_index >= 0:
+            if revisions[versions[earliest_index]] is True:
+                break
+            earliest_index -= 1
+        earliest_index = 0 if earliest_index < 0 else earliest_index
+        if latest_index == -1:
+            return False, 'not supported since v%s' % (versions[earliest_index])
+        else:
+            return False, 'not supported since %s, before %s' % (versions[earliest_index], versions[latest_index])
 
     def _get_basic_url(self, is_perobject):
         url_libs = None
@@ -242,11 +277,15 @@ class NAPIManager(object):
         selector = self.module.params['clone']['selector']
         clone_params_schema = metadata[selector]['params']
         clone_urls = metadata[selector]['urls']
+        clone_revisions = metadata[selector]['revision']
+        matched, checking_message = self._version_matched(clone_revisions)
+        if not matched:
+            self.version_check_warnings.append('selector:%s %s' % (selector, checking_message))
         real_params_keys = set()
         if self.module.params['clone']['self']:
             real_params_keys = set(self.module.params['clone']['self'].keys())
         if real_params_keys != set(clone_params_schema):
-            self.module.fail_json(msg='expect params in self:%s, real params:%s' % (list(clone_params_schema), list(real_params_keys)))
+            self.module.fail_json(msg='expect params in self:%s, given params:%s' % (list(clone_params_schema), list(real_params_keys)))
         url = None
         if 'adom' in clone_params_schema and not clone_urls[0].endswith('{adom}'):
             if self.module.params['clone']['self']['adom'] == 'global':
@@ -291,13 +330,17 @@ class NAPIManager(object):
         selector = self.module.params['move']['selector']
         move_params = metadata[selector]['params']
         move_urls = metadata[selector]['urls']
+        move_revisions = metadata[selector]['revision']
+        matched, checking_message = self._version_matched(move_revisions)
+        if not matched:
+            self.version_check_warnings.append('selector:%s %s' % (selector, checking_message))
         if not len(move_urls):
             raise AssertionError('unexpected move urls set')
         real_params_keys = set()
         if self.module.params['move']['self']:
             real_params_keys = set(self.module.params['move']['self'].keys())
         if real_params_keys != set(move_params):
-            self.module.fail_json(msg='expect params in self:%s, real params:%s' % (list(move_params), list(real_params_keys)))
+            self.module.fail_json(msg='expect params in self:%s, given params:%s' % (list(move_params), list(real_params_keys)))
 
         url = None
         if 'adom' in move_params and not move_urls[0].endswith('{adom}'):
@@ -341,13 +384,17 @@ class NAPIManager(object):
         selector = self.module.params['facts']['selector']
         fact_params = metadata[selector]['params']
         fact_urls = metadata[selector]['urls']
+        fact_revisions = metadata[selector]['revision']
+        matched, checking_message = self._version_matched(fact_revisions)
+        if not matched:
+            self.version_check_warnings.append('selector:%s %s' % (selector, checking_message))
         if not len(fact_urls):
             raise AssertionError('unexpected fact urls set')
         real_params_keys = set()
         if self.module.params['facts']['params']:
             real_params_keys = set(self.module.params['facts']['params'].keys())
         if real_params_keys != set(fact_params):
-            self.module.fail_json(msg='expect params:%s, real params:%s' % (list(fact_params), list(real_params_keys)))
+            self.module.fail_json(msg='expect params:%s, given params:%s' % (list(fact_params), list(real_params_keys)))
         url = None
         if 'adom' in fact_params and not fact_urls[0].endswith('{adom}'):
             if self.module.params['facts']['params']['adom'] == 'global':
@@ -516,7 +563,17 @@ class NAPIManager(object):
                     result['result_code_overriding'] = 'rc code:%s is overridden to success' % (rc_code)
         if self.system_status:
             result['system_information'] = self.system_status
-        self.module.exit_json(rc=rc, meta=result, failed=failed, changed=changed)
+        if len(self.version_check_warnings):
+            version_check_warning = dict()
+            version_check_warning['mismatches'] = self.version_check_warnings
+            assert(self.system_status)
+            version_check_warning['system_version'] = 'v%s.%s.%s' % (self.system_status['Major'],
+                                                                     self.system_status['Minor'],
+                                                                     self.system_status['Patch'])
+            self.module.warn('Ansible has detected version mismatch between FortiManager and your playbook, see more details by appending option -vvv')
+            self.module.exit_json(rc=rc, meta=result, version_check_warning=version_check_warning, failed=failed, changed=changed)
+        else:
+            self.module.exit_json(rc=rc, meta=result, failed=failed, changed=changed)
 
     def do_nonexist_exit(self):
         rc = 0

--- a/templates/code.j2
+++ b/templates/code.j2
@@ -92,9 +92,9 @@ def main():
         fmgr = NAPIManager(jrpc_urls, perobject_jrpc_urls, module_primary_key, url_params, module, connection, top_level_schema_name={% if top_level_schema_name -%}'{{top_level_schema_name}}'{% else -%}None{%- endif %})
         fmgr.validate_parameters(params_validation_blob)
         {%- if not is_partial %}
-        fmgr.process_curd()
+        fmgr.process_curd(argument_specs=module_arg_spec)
         {%- else %}
-        fmgr.process_partial_curd()
+        fmgr.process_partial_curd(argument_specs=module_arg_spec)
         {%- endif %}
     else:
         module.fail_json(msg='MUST RUN IN HTTPAPI MODE')

--- a/templates/exec_code.j2
+++ b/templates/exec_code.j2
@@ -75,7 +75,7 @@ def main():
         connection.set_option('enable_log', module.params['enable_log'] if 'enable_log' in module.params else False)
         fmgr = NAPIManager(jrpc_urls, perobject_jrpc_urls, None, url_params, module, connection, top_level_schema_name={% if top_level_schema_name -%}'{{top_level_schema_name}}'{% else -%}None{%- endif %})
         fmgr.validate_parameters(params_validation_blob)
-        fmgr.process_exec()
+        fmgr.process_exec(argument_specs=module_arg_spec)
     else:
         module.fail_json(msg='MUST RUN IN HTTPAPI MODE')
     module.exit_json(meta=module.params)


### PR DESCRIPTION
1.  **multi-versioning checking for `fmgr_fact` [module](https://ansible-galaxy-fortimanager-docs.readthedocs.io/en/galaxy-2.1.0/fmgr_fact.html): **

Playbook:
```
   - name: fact gathering
     fmgr_fact:
        enable_log: True
        facts:
            selector: 'user_saml'
            params:
                adom: 'root'
                saml: 'foo'
```
result:
```
    "version_check_warning": {
        "mismatches": [
            "selector:user_saml not supported until in v6.4.0"
        ],
        "system_version": "v6.0.0"
    }
}
```

2.  **multi-versioning for `fmgr_move` [module](https://ansible-galaxy-fortimanager-docs.readthedocs.io/en/galaxy-2.1.0/fmgr_move.html):**

Playbook:
```
   - name: Move a firewall vip object
     fmgr_move:
       move:
         selector: 'filefilter_profile_rules'
         target: 'filefilter_profile_rules0'
         action: 'before'
         self:
           adom: 'root'
           rules: 'filefilter_profile_rules1'
           profile: 'filefilter_profile'
```

result:
```
    "version_check_warning": {
        "mismatches": [
            "selector:filefilter_profile_rules not supported until in v6.4.2"
        ],
        "system_version": "v6.0.0"
    }
}
```

3.  **multi-versioning for `fmgr_clone` [module](https://ansible-galaxy-fortimanager-docs.readthedocs.io/en/galaxy-2.1.0/fmgr_clone.html):**

Playbook:
```
   - name: clone an vip object using fmgr_clone module.
     fmgr_clone:
       clone:
        selector: 'extendercontroller_simprofile'
        self:
          adom: 'root'
          sim_profile: 'simprofile0'
        target:
          name: 'simprofile1'
```

result:
```
    "version_check_warning": {
        "mismatches": [
            "selector:extendercontroller_simprofile not supported until in v6.4.5"
        ],
        "system_version": "v6.0.0"
    }
}
```
4.  **multi-versioning for Full CRUD `fmgr_firewall_address`  [module](https://ansible-galaxy-fortimanager-docs.readthedocs.io/en/galaxy-2.1.0/docgen/fmgr_firewall_address.html):**

playbook:
```
   - name: Configure IPv4 addresses.
     fmgr_firewall_address:
        bypass_validation: False
        adom: root
        state: present
        firewall_address:
           allow-routing: disable
           associated-interface: any
           name: 'ansible-test'
           visibility: disable
           node-ip-only: disable
```
result:
```
    "version_check_warning": {
        "mismatches": [
            "param: firewall_address-->visibility not supported since v6.2.5",
            "param: firewall_address-->node-ip-only not supported until in v7.0.0"
        ],
        "system_version": "v6.4.0"
    }
}

    "version_check_warning": {
        "mismatches": [
            "param: firewall_address-->node-ip-only not supported until in v7.0.0"
        ],
        "system_version": "v6.0.0"
    }
}

```


5.  **multi-versioning for Partial CRUD `fmgr_system_global`  [module](https://ansible-galaxy-fortimanager-docs.readthedocs.io/en/galaxy-2.1.0/docgen/fmgr_system_global.html):**

playbook:
```
   - name: Configure Global Parameter
     fmgr_system_global:
        system_global:
            timezone: '01'
            per-policy-lock: 'disable'
            private-data-encryption: 'disable'
            object-revision-status: 'disable'
```

result:
```

    "version_check_warning": {
        "mismatches": [
            "param: system_global-->private-data-encryption not supported until in v6.2.5",
            "param: system_global-->per-policy-lock not supported until in v6.4.0",
            "param: system_global-->object-revision-status not supported until in v7.0.0"
        ],
        "system_version": "v6.0.0"
    }
}

    "version_check_warning": {
        "mismatches": [
            "param: system_global-->object-revision-status not supported until in v7.0.0"
        ],
        "system_version": "v6.4.0"
    }
}
```