### PR TITLE
fixed top level versioing infomation

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -1418,6 +1418,7 @@ def resolve_generic_schema(url, _not_used_schema, doc_template, code_template, m
                   'in_path_params': the_one_in_path_params,
                   'jrpc_urls': mutiurls_names if not is_object_member else [e + '/' + url_sufix for e in mutiurls_names],
                   'perobject_jrpc_urls': perobject_mutiurls_names if not is_object_member else [e + '/' + url_sufix for e in perobject_mutiurls_names],
+                  'revisions': super_digest[url]['revision'],
                   'mkey': mkey,
                   'pvb': schema_beautify(pvbs[canonical_path], 4, 1, False, True) if canonical_path in pvbs else [],
                   'top_level_schema_name': wrapper_dataset[canonical_path] if canonical_path in wrapper_dataset else (the_unique_schema['name'] if the_unique_schema else None),

--- a/templates/code.j2
+++ b/templates/code.j2
@@ -76,6 +76,12 @@ def main():
         '{{level2_name}}': {
             'required': False,
             'type': 'dict',
+            'revision': {
+                {%- for ver in revisions %}
+                '{{ ver }}': True
+                {%- if loop.index != loop.length -%}, {%- endif %}
+                {%- endfor %}
+            },
             'options':{{body_schemas}}
         }
     }

--- a/templates/exec_code.j2
+++ b/templates/exec_code.j2
@@ -59,6 +59,12 @@ def main():
         '{{level2_name}}': {
             'required': False,
             'type': 'dict',
+            'revision': {
+                {%- for ver in revisions %}
+                '{{ ver }}': True
+                {%- if loop.index != loop.length -%}, {%- endif %}
+                {%- endfor %}
+            },
             'options':{{body_schemas}}
         }
         {%- endif %}


### PR DESCRIPTION
```
$cat fmgr_webfilter_profile_filefilter.yml
- hosts: fortimanagers
  connection: httpapi
  collections:
  - fortinet.fortimanager
  vars:
   ansible_httpapi_use_ssl: yes
   ansible_httpapi_validate_certs: no
   ansible_httpapi_port: 443
  gather_facts: True
  tasks:
   - name: fact gathering
     fmgr_webfilter_profile_filefilter:
        adom: 'root'
        profile: 'foo.profile'
        webfilter_profile_filefilter:
            status: enable

```

```
    "version_check_warning": {
        "mismatches": [
            "param: webfilter_profile_filefilter not supported until in v6.2.1",
            "param: webfilter_profile_filefilter-->status not supported until in v6.2.1"
        ],
        "system_version": "v6.0.0"
    }
}
```